### PR TITLE
Changed Symfony security in order to perform an stateless auth.

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,13 +1,6 @@
 framework:
     secret: '%env(APP_SECRET)%'
 
-    # Enables session support. Note that the session will ONLY be started if you read or write from it.
-    # Remove or comment this section to explicitly disable session support.
-    session:
-        handler_id: null
-        cookie_secure: auto
-        cookie_samesite: lax
-
     serializer:
         enabled: true
         mapping:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -5,28 +5,28 @@ security:
 
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
-        # used to reload user from session & other features (e.g. switch_user)
         app_user_provider:
-            entity:
-                class: App\Entity\Guardian
-                property: email
+            id: App\Component\Auth\Provider\UserProvider
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
-        main:
-            anonymous: ~
-            logout: ~
-
+        auth:
+            anonymous: true
+            pattern: ^/api/auth
             guard:
                 authenticators:
                     - App\Security\TokenAuthenticator
-
-            # activate different ways to authenticate
-            # https://symfony.com/doc/current/security.html#firewalls-authentication
-
-            # https://symfony.com/doc/current/security/impersonating_user.html
-            # switch_user: true
+            provider: app_user_provider
+            stateless: true
+        main:
+            anonymous: false
+            guard:
+                authenticators:
+                    - App\Security\TokenAuthenticator
+            pattern: ^/api
+            provider: app_user_provider
+            stateless: true
 
     access_control:
         - { path: ^/api/auth, roles: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/src/Component/Auth/Provider/UserProvider.php
+++ b/src/Component/Auth/Provider/UserProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Component\Auth\Provider;
+
+use App\Component\JWT\Service\JWTBuilder;
+use App\Component\Person\Service\GuardianManager;
+use App\Entity\Guardian;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class UserProvider implements UserProviderInterface
+{
+    /**
+     * @var GuardianManager
+     */
+    protected $guardianManager;
+    /**
+     * @var JWTBuilder
+     */
+    protected $jwtBuilder;
+
+    /**
+     * UserProvider constructor.
+     * @param GuardianManager $guardianManager
+     * @param JWTBuilder $jwtBuilder
+     */
+    public function __construct(GuardianManager $guardianManager, JWTBuilder $jwtBuilder)
+    {
+        $this->guardianManager = $guardianManager;
+        $this->jwtBuilder = $jwtBuilder;
+    }
+
+    /**
+     * @param string $username
+     * @return UserInterface|null
+     */
+    public function loadUserByUsername($username): ?UserInterface
+    {
+        return $this->guardianManager->getByEmail($username);
+    }
+
+    /**
+     * @param UserInterface $user
+     * @return UserInterface|void
+     */
+    public function refreshUser(UserInterface $user)
+    {
+        throw new UnsupportedUserException();
+    }
+
+    /**
+     * @param string $class
+     * @return bool
+     */
+    public function supportsClass($class): bool
+    {
+        return Guardian::class === $class;
+    }
+}

--- a/src/Security/TokenAuthenticator.php
+++ b/src/Security/TokenAuthenticator.php
@@ -84,9 +84,6 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
     {
         $data = [
             'message' => strtr($exception->getMessageKey(), $exception->getMessageData())
-
-            // or to translate this message
-            // $this->translator->trans($exception->getMessageKey(), $exception->getMessageData())
         ];
 
         return new JsonResponse($data, Response::HTTP_FORBIDDEN);


### PR DESCRIPTION
Authentication should be performed using the API token instead of a session cookie